### PR TITLE
Change operator precedence.

### DIFF
--- a/src/main/antlr4/io/proleap/vb6/VisualBasic6.g4
+++ b/src/main/antlr4/io/proleap/vb6/VisualBasic6.g4
@@ -525,6 +525,15 @@ valueStmt
    | midStmt # vsMid
    | ADDRESSOF WS valueStmt # vsAddressOf
    | implicitCallStmt_InStmt WS? ASSIGN WS? valueStmt # vsAssign
+   | valueStmt WS? POW WS? valueStmt # vsPow
+   | MINUS WS? valueStmt # vsNegation
+   | PLUS WS? valueStmt # vsPlus
+   | valueStmt WS? DIV WS? valueStmt # vsDiv
+   | valueStmt WS? MULT WS? valueStmt # vsMult
+   | valueStmt WS? MOD WS? valueStmt # vsMod
+   | valueStmt WS? PLUS WS? valueStmt # vsAdd
+   | valueStmt WS? MINUS WS? valueStmt # vsMinus
+   | valueStmt WS AMPERSAND WS valueStmt # vsAmp
    | valueStmt WS IS WS valueStmt # vsIs
    | valueStmt WS LIKE WS valueStmt # vsLike
    | valueStmt WS? GEQ WS? valueStmt # vsGeq
@@ -533,21 +542,12 @@ valueStmt
    | valueStmt WS? LT WS? valueStmt # vsLt
    | valueStmt WS? NEQ WS? valueStmt # vsNeq
    | valueStmt WS? EQ WS? valueStmt # vsEq
-   | valueStmt WS AMPERSAND WS valueStmt # vsAmp
-   | MINUS WS? valueStmt # vsNegation
-   | PLUS WS? valueStmt # vsPlus
-   | valueStmt WS? PLUS WS? valueStmt # vsAdd
-   | valueStmt WS? MOD WS? valueStmt # vsMod
-   | valueStmt WS? DIV WS? valueStmt # vsDiv
-   | valueStmt WS? MULT WS? valueStmt # vsMult
-   | valueStmt WS? MINUS WS? valueStmt # vsMinus
-   | valueStmt WS? POW WS? valueStmt # vsPow
    | valueStmt WS IMP WS valueStmt # vsImp
    | valueStmt WS EQV WS valueStmt # vsEqv
-   | valueStmt WS? XOR WS? valueStmt # vsXor
-   | valueStmt WS? OR WS? valueStmt # vsOr
-   | valueStmt WS AND WS valueStmt # vsAnd
    | NOT WS valueStmt # vsNot
+   | valueStmt WS AND WS valueStmt # vsAnd
+   | valueStmt WS? OR WS? valueStmt # vsOr
+   | valueStmt WS? XOR WS? valueStmt # vsXor
    ;
 
 variableStmt

--- a/src/test/resources/com/microsoft/msdn/statements/Event2.cls.tree
+++ b/src/test/resources/com/microsoft/msdn/statements/Event2.cls.tree
@@ -75,18 +75,18 @@
 							(doLoopStmt Do   While   
 								(valueStmt 
 									(valueStmt 
-										(valueStmt 
-											(implicitCallStmt_InStmt 
-												(iCS_S_VariableOrProcedureCall 
-													(ambiguousIdentifier Timer))))   <   
-										(valueStmt 
-											(implicitCallStmt_InStmt 
-												(iCS_S_VariableOrProcedureCall 
-													(ambiguousIdentifier dblStart)))))   +   
-									(valueStmt 
 										(implicitCallStmt_InStmt 
 											(iCS_S_VariableOrProcedureCall 
-												(ambiguousIdentifier Duration))))) \n         
+												(ambiguousIdentifier Timer))))   <   
+									(valueStmt 
+										(valueStmt 
+											(implicitCallStmt_InStmt 
+												(iCS_S_VariableOrProcedureCall 
+													(ambiguousIdentifier dblStart))))   +   
+										(valueStmt 
+											(implicitCallStmt_InStmt 
+												(iCS_S_VariableOrProcedureCall 
+													(ambiguousIdentifier Duration)))))) \n         
 								(block 
 									(blockStmt 
 										(ifThenElseStmt 
@@ -94,16 +94,14 @@
 												(ifConditionStmt 
 													(valueStmt 
 														(valueStmt 
-															(implicitCallStmt_InStmt 
-																(iCS_S_VariableOrProcedureCall 
-																	(ambiguousIdentifier Timer))))   -   
-														(valueStmt 
 															(valueStmt 
 																(implicitCallStmt_InStmt 
 																	(iCS_S_VariableOrProcedureCall 
-																		(ambiguousIdentifier dblSoFar))))   >=   
-															(valueStmt 
-																(literal 1)))))   Then \n             
+																		(ambiguousIdentifier Timer))))   -   
+															(valueStmt (implicitCallStmt_InStmt 
+																(iCS_S_VariableOrProcedureCall 
+																	(ambiguousIdentifier dblSoFar)))))   >=   
+														(valueStmt (literal 1))))   Then \n             
 												(block 
 													(blockStmt 
 														(letStmt 
@@ -116,7 +114,7 @@
 																		(iCS_S_VariableOrProcedureCall 
 																			(ambiguousIdentifier dblSoFar))))   +   
 																(valueStmt 
-																	(literal 1))))) \n             
+																	(literal 1))))) \n                      
 													(blockStmt 
 														(raiseEventStmt RaiseEvent   
 															(ambiguousIdentifier UpdateTime) ( 

--- a/src/test/resources/com/microsoft/msdn/statements/ForNext.cls.tree
+++ b/src/test/resources/com/microsoft/msdn/statements/ForNext.cls.tree
@@ -261,14 +261,14 @@
 												(ifConditionStmt 
 													(valueStmt 
 														(valueStmt 
-															(implicitCallStmt_InStmt 
-																(iCS_S_VariableOrProcedureCall 
-																	(ambiguousIdentifier i))))   Mod   
+															(valueStmt 
+																(implicitCallStmt_InStmt 
+																	(iCS_S_VariableOrProcedureCall 
+																		(ambiguousIdentifier i))))   Mod   
 														(valueStmt 
-															(valueStmt 
-																(literal 2))   =   
-															(valueStmt 
-																(literal 1)))))   Then \n         
+															(literal 2)))   =   
+														(valueStmt 
+															(literal 1))))   Then \n         
 												(block 
 													(blockStmt 
 														(letStmt 

--- a/src/test/resources/com/microsoft/msdn/statements/RaiseEvent2.cls.tree
+++ b/src/test/resources/com/microsoft/msdn/statements/RaiseEvent2.cls.tree
@@ -75,18 +75,18 @@
 							(doLoopStmt Do   While   
 								(valueStmt 
 									(valueStmt 
-										(valueStmt 
-											(implicitCallStmt_InStmt 
-												(iCS_S_VariableOrProcedureCall 
-													(ambiguousIdentifier Timer))))   <   
-										(valueStmt 
-											(implicitCallStmt_InStmt 
-												(iCS_S_VariableOrProcedureCall 
-													(ambiguousIdentifier dblStart)))))   +   
-									(valueStmt 
 										(implicitCallStmt_InStmt 
 											(iCS_S_VariableOrProcedureCall 
-												(ambiguousIdentifier Duration))))) \n         
+												(ambiguousIdentifier Timer))))   <   
+									(valueStmt 
+										(valueStmt 
+											(implicitCallStmt_InStmt 
+												(iCS_S_VariableOrProcedureCall 
+													(ambiguousIdentifier dblStart))))   +   
+										(valueStmt 
+											(implicitCallStmt_InStmt 
+												(iCS_S_VariableOrProcedureCall 
+													(ambiguousIdentifier Duration)))))) \n         
 								(block 
 									(blockStmt 
 										(ifThenElseStmt 
@@ -94,16 +94,14 @@
 												(ifConditionStmt 
 													(valueStmt 
 														(valueStmt 
-															(implicitCallStmt_InStmt 
-																(iCS_S_VariableOrProcedureCall 
-																	(ambiguousIdentifier Timer))))   -   
-														(valueStmt 
 															(valueStmt 
 																(implicitCallStmt_InStmt 
 																	(iCS_S_VariableOrProcedureCall 
-																		(ambiguousIdentifier dblSoFar))))   >=   
-															(valueStmt 
-																(literal 1)))))   Then \n             
+																		(ambiguousIdentifier Timer))))   -   
+															(valueStmt (implicitCallStmt_InStmt 
+																(iCS_S_VariableOrProcedureCall 
+																	(ambiguousIdentifier dblSoFar)))))   >=   
+														(valueStmt (literal 1))))   Then \n             
 												(block 
 													(blockStmt 
 														(letStmt 

--- a/src/test/resources/io/proleap/vb6/ast/statements/WhileWend.cls.tree
+++ b/src/test/resources/io/proleap/vb6/ast/statements/WhileWend.cls.tree
@@ -68,14 +68,14 @@
 										(whileWendStmt While   
 											(valueStmt 
 												(valueStmt 
-													(implicitCallStmt_InStmt 
-														(iCS_S_VariableOrProcedureCall 
-															(ambiguousIdentifier I))))   Mod   
+												  (valueStmt 
+														(implicitCallStmt_InStmt 
+															(iCS_S_VariableOrProcedureCall 
+																(ambiguousIdentifier I))))   Mod   
+													(valueStmt 
+														(literal 15)))   <>   
 												(valueStmt 
-													(valueStmt 
-														(literal 15))   <>   
-													(valueStmt 
-														(literal 0)))) \n\t\t 
+													(literal 0))) \n\t\t 
 											(block 
 												(blockStmt 
 													(letStmt 


### PR DESCRIPTION
I think that the order of priority of operators in VB also applies to VB 6. (Although the description is VB.NET, it is linked from Operator Precedence of VB 6 document.)

- https://msdn.microsoft.com/en-us/library/aa262417(v=vs.60).aspx
- https://docs.microsoft.com/en-us/dotnet/visual-basic/language-reference/operators/operator-precedence