### PR TITLE
Fix order of outputList_Expresson.

### DIFF
--- a/src/main/antlr4/io/proleap/vb6/VisualBasic6.g4
+++ b/src/main/antlr4/io/proleap/vb6/VisualBasic6.g4
@@ -430,8 +430,8 @@ outputList
    ;
 
 outputList_Expression
-   : valueStmt
-   | (SPC | TAB) (WS? LPAREN WS? argsCall WS? RPAREN)?
+   : (SPC | TAB) (WS? LPAREN WS? argsCall WS? RPAREN)?
+   | valueStmt
    ;
 
 printStmt

--- a/src/test/resources/com/microsoft/msdn/statements/Print.cls.tree
+++ b/src/test/resources/com/microsoft/msdn/statements/Print.cls.tree
@@ -30,12 +30,7 @@
 									(outputList_Expression 
 										(valueStmt 
 											(literal "Zone 1"))) ;   
-									(outputList_Expression 
-										(valueStmt 
-											(implicitCallStmt_InStmt 
-												(iCS_S_VariableOrProcedureCall 
-													(ambiguousIdentifier 
-														(ambiguousKeyword Tab))))))   ;   
+									(outputList_Expression Tab)   ;   
 									(outputList_Expression 
 										(valueStmt 
 											(literal "Zone 2")))))) \n 
@@ -58,16 +53,11 @@
 								(valueStmt 
 									(literal #1)) ,   
 								(outputList 
-									(outputList_Expression 
-										(valueStmt 
-											(implicitCallStmt_InStmt 
-												(iCS_S_ProcedureOrArrayCall 
-													(ambiguousIdentifier 
-														(ambiguousKeyword Spc)) ( 
-													(argsCall 
-														(argCall 
-															(valueStmt 
-																(literal 5)))) )))))   ;   
+									(outputList_Expression Spc ( 
+										(argsCall 
+											(argCall 
+												(valueStmt 
+													(literal 5)))) ))   ;   
 									(outputList_Expression 
 										(valueStmt 
 											(literal "5 leading spaces ")))))) \n 
@@ -76,16 +66,11 @@
 								(valueStmt 
 									(literal #1)) ,   
 								(outputList 
-									(outputList_Expression 
-										(valueStmt 
-											(implicitCallStmt_InStmt 
-												(iCS_S_ProcedureOrArrayCall 
-													(ambiguousIdentifier 
-														(ambiguousKeyword Tab)) ( 
-													(argsCall 
-														(argCall 
-															(valueStmt 
-																(literal 10)))) )))))   ;   
+									(outputList_Expression Tab ( 
+										(argsCall 
+											(argCall 
+												(valueStmt 
+													(literal 10)))) ))   ;   
 									(outputList_Expression 
 										(valueStmt 
 											(literal "Hello")))))) \n \n \n 

--- a/src/test/resources/io/proleap/vb6/ast/statements/Write.cls.tree
+++ b/src/test/resources/io/proleap/vb6/ast/statements/Write.cls.tree
@@ -78,16 +78,11 @@
 											(implicitCallStmt_InStmt 
 												(iCS_S_VariableOrProcedureCall 
 													(ambiguousIdentifier MovieTitle))))) ;   
-									(outputList_Expression 
-										(valueStmt 
-											(implicitCallStmt_InStmt 
-												(iCS_S_ProcedureOrArrayCall 
-													(ambiguousIdentifier 
-														(ambiguousKeyword Tab)) ( 
-													(argsCall 
-														(argCall 
-															(valueStmt 
-																(literal 20)))) ))))) ;   
+									(outputList_Expression Tab ( 
+										(argsCall 
+											(argCall 
+												(valueStmt 
+													(literal 20)))) )) ;   
 									(outputList_Expression 
 										(valueStmt 
 											(implicitCallStmt_InStmt 
@@ -103,31 +98,21 @@
 														(argCall 
 															(valueStmt 
 																(literal "@@@@")))) ))))) ; \t 
-									(outputList_Expression 
-										(valueStmt 
-											(implicitCallStmt_InStmt 
-												(iCS_S_ProcedureOrArrayCall 
-													(ambiguousIdentifier 
-														(ambiguousKeyword Tab)) ( 
-													(argsCall 
-														(argCall 
-															(valueStmt 
-																(literal 40)))) ))))) ;   
+									(outputList_Expression Tab ( 
+										(argsCall 
+											(argCall 
+												(valueStmt 
+													(literal 40)))) )) ;   
 									(outputList_Expression 
 										(valueStmt 
 											(implicitCallStmt_InStmt 
 												(iCS_S_VariableOrProcedureCall 
 													(ambiguousIdentifier MovieSubTitle))))) ; \t 
-									(outputList_Expression 
-										(valueStmt 
-											(implicitCallStmt_InStmt 
-												(iCS_S_ProcedureOrArrayCall 
-													(ambiguousIdentifier 
-														(ambiguousKeyword Tab)) ( 
-													(argsCall 
-														(argCall 
-															(valueStmt 
-																(literal 60)))) ))))) ;   
+									(outputList_Expression Tab ( 
+										(argsCall 
+											(argCall 
+												(valueStmt 
+													(literal 60)))) )) ;   
 									(outputList_Expression 
 										(valueStmt 
 											(implicitCallStmt_InStmt 
@@ -144,16 +129,11 @@
 														(argCall 
 															(valueStmt 
 																(literal "m/d/yyyy")))) ))))) ; \t 
-									(outputList_Expression 
-										(valueStmt 
-											(implicitCallStmt_InStmt 
-												(iCS_S_ProcedureOrArrayCall 
-													(ambiguousIdentifier 
-														(ambiguousKeyword Tab)) ( 
-													(argsCall 
-														(argCall 
-															(valueStmt 
-																(literal 80)))) ))))) ;   
+									(outputList_Expression Tab ( 
+										(argsCall 
+											(argCall 
+												(valueStmt 
+													(literal 80)))) )) ;   
 									(outputList_Expression 
 										(valueStmt 
 											(implicitCallStmt_InStmt 


### PR DESCRIPTION
Spc or Tab keywards should be used in preference to valueStmt.