### PR TITLE
Fix Not operator rules.

### DIFF
--- a/src/main/antlr4/io/proleap/vb6/VisualBasic6.g4
+++ b/src/main/antlr4/io/proleap/vb6/VisualBasic6.g4
@@ -569,11 +569,9 @@ unlockStmt
 // operator precedence is represented by rule order
 valueStmt
    : literal                                                         # vsLiteral
-   | implicitCallStmt_InStmt                                         # vsICS
    | LPAREN WS? valueStmt (WS? COMMA WS? valueStmt)* WS? RPAREN      # vsStruct
    | NEW WS valueStmt                                                # vsNew
    | typeOfStmt                                                      # vsTypeOf
-   | midStmt                                                         # vsMid
    | ADDRESSOF WS valueStmt                                          # vsAddressOf
    | implicitCallStmt_InStmt WS? ASSIGN WS? valueStmt                # vsAssign
    | valueStmt WS? POW WS? valueStmt                                 # vsPow
@@ -593,12 +591,14 @@ valueStmt
    | valueStmt WS? GEQ WS? valueStmt                                 # vsGeq
    | valueStmt WS LIKE WS valueStmt                                  # vsLike
    | valueStmt WS IS WS valueStmt                                    # vsIs
-   | NOT WS valueStmt                                                # vsNot
+   | NOT (WS valueStmt | LPAREN WS? valueStmt WS? RPAREN)            # vsNot
    | valueStmt WS? AND WS? valueStmt                                 # vsAnd
    | valueStmt WS? OR WS? valueStmt                                  # vsOr
    | valueStmt WS? XOR WS? valueStmt                                 # vsXor
    | valueStmt WS? EQV WS? valueStmt                                 # vsEqv
    | valueStmt WS? IMP WS? valueStmt                                 # vsImp
+   | implicitCallStmt_InStmt                                         # vsICS
+   | midStmt                                                         # vsMid
    ;
 
 variableStmt

--- a/src/test/java/io/proleap/vb6/ast/operators/NotTest.java
+++ b/src/test/java/io/proleap/vb6/ast/operators/NotTest.java
@@ -1,0 +1,18 @@
+package io.proleap.vb6.ast.operators;
+
+import java.io.File;
+
+import org.junit.Test;
+import io.proleap.vb6.runner.VbParseTestRunner;
+import io.proleap.vb6.runner.impl.VbParseTestRunnerImpl;
+
+public class NotTest {
+
+	@Test
+	public void test() throws Exception {
+		final File inputFile = new File("src/test/resources/io/proleap/vb6/ast/operators/Not.cls");
+		final VbParseTestRunner runner = new VbParseTestRunnerImpl();
+		runner.parseFile(inputFile);
+	}
+}
+

--- a/src/test/resources/io/proleap/vb6/ast/operators/Not.cls
+++ b/src/test/resources/io/proleap/vb6/ast/operators/Not.cls
@@ -1,0 +1,6 @@
+Dim A, B, C, D, MyCheck
+A = 10: B = 8: C = 6: D = Null    ' Initialize variables.
+MyCheck = Not(A > B)    ' Returns False.
+MyCheck = Not(B > A)    ' Returns True.
+MyCheck = Not(C > D)    ' Returns Null.
+MyCheck = Not A    ' Returns -11 (bitwise comparison).

--- a/src/test/resources/io/proleap/vb6/ast/operators/Not.cls.tree
+++ b/src/test/resources/io/proleap/vb6/ast/operators/Not.cls.tree
@@ -1,0 +1,102 @@
+(startRule 
+	(module 
+		(moduleBody 
+			(moduleBodyElement 
+				(moduleBlock 
+					(block 
+						(blockStmt 
+							(variableStmt Dim   
+								(variableListStmt 
+									(variableSubStmt 
+										(ambiguousIdentifier A)) ,   
+									(variableSubStmt 
+										(ambiguousIdentifier B)) ,   
+									(variableSubStmt 
+										(ambiguousIdentifier C)) ,   
+									(variableSubStmt 
+										(ambiguousIdentifier D)) ,   
+									(variableSubStmt 
+										(ambiguousIdentifier MyCheck))))) \n 
+						(blockStmt 
+							(letStmt 
+								(implicitCallStmt_InStmt 
+									(iCS_S_VariableOrProcedureCall 
+										(ambiguousIdentifier A)))   =   
+								(valueStmt 
+									(literal 10)))) :  
+						(blockStmt 
+							(letStmt 
+								(implicitCallStmt_InStmt 
+									(iCS_S_VariableOrProcedureCall 
+										(ambiguousIdentifier B)))   =   
+								(valueStmt 
+									(literal 8)))) :  
+						(blockStmt 
+							(letStmt 
+								(implicitCallStmt_InStmt 
+									(iCS_S_VariableOrProcedureCall 
+										(ambiguousIdentifier C)))   =   
+								(valueStmt 
+									(literal 6)))) :  
+						(blockStmt 
+							(letStmt 
+								(implicitCallStmt_InStmt 
+									(iCS_S_VariableOrProcedureCall 
+										(ambiguousIdentifier D)))   =   
+								(valueStmt 
+									(literal Null)))) \n 
+						(blockStmt 
+							(letStmt 
+								(implicitCallStmt_InStmt 
+									(iCS_S_VariableOrProcedureCall 
+										(ambiguousIdentifier MyCheck)))   =   
+								(valueStmt Not ( 
+									(valueStmt 
+										(valueStmt 
+											(implicitCallStmt_InStmt 
+												(iCS_S_VariableOrProcedureCall 
+													(ambiguousIdentifier A))))   >   
+										(valueStmt 
+											(implicitCallStmt_InStmt 
+												(iCS_S_VariableOrProcedureCall 
+													(ambiguousIdentifier B))))) )))) \n 
+						(blockStmt 
+							(letStmt 
+								(implicitCallStmt_InStmt 
+									(iCS_S_VariableOrProcedureCall 
+										(ambiguousIdentifier MyCheck)))   =   
+								(valueStmt Not ( 
+									(valueStmt 
+										(valueStmt 
+											(implicitCallStmt_InStmt 
+												(iCS_S_VariableOrProcedureCall 
+													(ambiguousIdentifier B))))   >   
+										(valueStmt 
+											(implicitCallStmt_InStmt 
+												(iCS_S_VariableOrProcedureCall 
+													(ambiguousIdentifier A))))) )))) \n 
+						(blockStmt 
+							(letStmt 
+								(implicitCallStmt_InStmt 
+									(iCS_S_VariableOrProcedureCall 
+										(ambiguousIdentifier MyCheck)))   =   
+								(valueStmt Not ( 
+									(valueStmt 
+										(valueStmt 
+											(implicitCallStmt_InStmt 
+												(iCS_S_VariableOrProcedureCall 
+													(ambiguousIdentifier C))))   >   
+										(valueStmt 
+											(implicitCallStmt_InStmt 
+												(iCS_S_VariableOrProcedureCall 
+													(ambiguousIdentifier D))))) )))) \n 
+						(blockStmt 
+							(letStmt 
+								(implicitCallStmt_InStmt 
+									(iCS_S_VariableOrProcedureCall 
+										(ambiguousIdentifier MyCheck)))   =   
+								(valueStmt Not   
+									(valueStmt 
+										(implicitCallStmt_InStmt 
+											(iCS_S_VariableOrProcedureCall 
+												(ambiguousIdentifier A)))))))))))) <EOF>)


### PR DESCRIPTION
When I used `Not` operator and parenthesis at same time, Not operator is evaluated `Not` procedure call.
For example:
```vb
MyCheck = Not A > B    ' No problem.
MyCheck = Not(A > B)   ' Evaluated as `Not` procedure call.
```

I fixed antlr rules file to evaluate as `Not` operator when use `Not` operator and parenthesis at same time. And I added test case for Not operator.